### PR TITLE
Fix README.md bad code block render

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ On Windows, the easiest way to set permanent environment variables (as of Window
 1. Clone this repository. Navigate to the folder with the source code on your machine in a terminal window.
 
 1. From there we recommend creating a [virtualenv](https://docs.python.org/3/library/venv.html) and activating it to avoid installing dependencies globaly on your computer.
-
-    `virtualenv -p python3 env`
-    `source env/bin/activate`
+```
+    virtualenv -p python3 env
+    source env/bin/activate
+```
 
 1. Install dependencies:
 


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x ] I acknowledge that all my contributions will be made under the project's license.

This for fixing issue #3 created by cut and pasting two commands rendered on the same line. `virtualenv` and `source` should be separated on two lines. 

![Capture d’écran, le 2020-12-08 à 8 02 08 PM](https://user-images.githubusercontent.com/36549301/101560555-8f2c0500-3991-11eb-8c22-8a03f6795ba7.png)


